### PR TITLE
Fixed error in cloud queue networking building

### DIFF
--- a/src/ispd/arquivo/xml/IconicoXML.java
+++ b/src/ispd/arquivo/xml/IconicoXML.java
@@ -132,7 +132,9 @@ public class IconicoXML {
      * @return Simulable queue network, in accordance to given model
      */
     public static RedeDeFilas newRedeDeFilas(final Document model) {
-        return new QueueNetworkBuilder(new WrappedDocument(model)).build();
+        return new QueueNetworkBuilder()
+                .parseDoc(new WrappedDocument(model))
+                .build();
     }
 
     /**
@@ -143,8 +145,9 @@ public class IconicoXML {
      * @return Simulable cloud queue network, in accordance to given model
      */
     public static RedeDeFilasCloud newRedeDeFilasCloud(final Document model) {
-        return (RedeDeFilasCloud) new CloudQueueNetworkBuilder(
-                new WrappedDocument(model)).build();
+        return (RedeDeFilasCloud) new CloudQueueNetworkBuilder()
+                .parseDoc(new WrappedDocument(model))
+                .build();
     }
 
     /**

--- a/src/ispd/arquivo/xml/IconicoXML.java
+++ b/src/ispd/arquivo/xml/IconicoXML.java
@@ -133,7 +133,7 @@ public class IconicoXML {
      */
     public static RedeDeFilas newRedeDeFilas(final Document model) {
         return new QueueNetworkBuilder()
-                .parseDoc(new WrappedDocument(model))
+                .parseDocument(new WrappedDocument(model))
                 .build();
     }
 
@@ -146,7 +146,7 @@ public class IconicoXML {
      */
     public static RedeDeFilasCloud newRedeDeFilasCloud(final Document model) {
         return (RedeDeFilasCloud) new CloudQueueNetworkBuilder()
-                .parseDoc(new WrappedDocument(model))
+                .parseDocument(new WrappedDocument(model))
                 .build();
     }
 

--- a/src/ispd/arquivo/xml/models/builders/CloudQueueNetworkBuilder.java
+++ b/src/ispd/arquivo/xml/models/builders/CloudQueueNetworkBuilder.java
@@ -31,12 +31,14 @@ public class CloudQueueNetworkBuilder extends QueueNetworkBuilder {
             new HashMap<>();
     private final List<CS_MaquinaCloud> cloudMachines = new ArrayList<>();
     private final List<CS_VirtualMac> virtualMachines = new ArrayList<>();
-    private final List<CS_Processamento> virtualMachineMasters =
-            new ArrayList<>();
+    private final List<CS_Processamento> virtualMachineMasters = new ArrayList<>();
 
-    public CloudQueueNetworkBuilder(final WrappedDocument doc) {
-        super(doc);
+    @Override
+    public QueueNetworkBuilder parseDoc(final WrappedDocument doc)
+    {
+        super.parseDoc(doc);
         doc.virtualMachines().forEach(this::processVirtualMachineElement);
+        return this;
     }
 
     private void processVirtualMachineElement(final WrappedElement e) {

--- a/src/ispd/arquivo/xml/models/builders/CloudQueueNetworkBuilder.java
+++ b/src/ispd/arquivo/xml/models/builders/CloudQueueNetworkBuilder.java
@@ -34,9 +34,9 @@ public class CloudQueueNetworkBuilder extends QueueNetworkBuilder {
     private final List<CS_Processamento> virtualMachineMasters = new ArrayList<>();
 
     @Override
-    public QueueNetworkBuilder parseDoc(final WrappedDocument doc)
+    public QueueNetworkBuilder parseDocument(final WrappedDocument doc)
     {
-        super.parseDoc(doc);
+        super.parseDocument(doc);
         doc.virtualMachines().forEach(this::processVirtualMachineElement);
         return this;
     }

--- a/src/ispd/arquivo/xml/models/builders/CloudQueueNetworkBuilder.java
+++ b/src/ispd/arquivo/xml/models/builders/CloudQueueNetworkBuilder.java
@@ -4,10 +4,12 @@ import ispd.arquivo.xml.utils.SwitchConnection;
 import ispd.arquivo.xml.utils.UserPowerLimit;
 import ispd.arquivo.xml.utils.WrappedDocument;
 import ispd.arquivo.xml.utils.WrappedElement;
+import ispd.escalonadorCloud.EscalonadorCloud;
 import ispd.motor.filas.RedeDeFilas;
 import ispd.motor.filas.RedeDeFilasCloud;
 import ispd.motor.filas.servidores.CS_Processamento;
 import ispd.motor.filas.servidores.CentroServico;
+import ispd.motor.filas.servidores.implementacao.CS_Maquina;
 import ispd.motor.filas.servidores.implementacao.CS_MaquinaCloud;
 import ispd.motor.filas.servidores.implementacao.CS_Switch;
 import ispd.motor.filas.servidores.implementacao.CS_VMM;
@@ -20,22 +22,36 @@ import java.util.Map;
 
 /**
  * Class to build a cloud queue network from a model in a
- * {@link WrappedDocument}. Construct an instance and call the method
- * {@link #build()}
+ * {@link WrappedDocument}. The usage is the same as in
+ * {@link QueueNetworkBuilder}.
  *
  * @see ispd.arquivo.xml.IconicoXML
  * @see QueueNetworkBuilder
  */
 public class CloudQueueNetworkBuilder extends QueueNetworkBuilder {
+    /**
+     * Overridden from superclass to support {@link CS_MaquinaCloud}s.
+     */
     private final Map<CentroServico, List<CS_MaquinaCloud>> clusterSlaves =
             new HashMap<>();
     private final List<CS_MaquinaCloud> cloudMachines = new ArrayList<>();
     private final List<CS_VirtualMac> virtualMachines = new ArrayList<>();
-    private final List<CS_Processamento> virtualMachineMasters = new ArrayList<>();
+    private final List<CS_Processamento> virtualMachineMasters =
+            new ArrayList<>();
 
+    /**
+     * Parse the required {@link CentroServico}s and {@link CS_VirtualMac}s
+     * from the given {@link WrappedDocument}.
+     *
+     * @param doc the {@link WrappedDocument} to be processed. Must contain a
+     *            valid <b>cloud</b> model.
+     * @return the called instance itself, so the call can be chained into a
+     * {@link #build()} if so desired.
+     * @throws IllegalStateException if this instance was already used to
+     *                               parse a {@link WrappedDocument}.
+     */
     @Override
-    public QueueNetworkBuilder parseDocument(final WrappedDocument doc)
-    {
+    public QueueNetworkBuilder parseDocument(final WrappedDocument doc) {
         super.parseDocument(doc);
         doc.virtualMachines().forEach(this::processVirtualMachineElement);
         return this;
@@ -58,6 +74,13 @@ public class CloudQueueNetworkBuilder extends QueueNetworkBuilder {
         this.virtualMachines.add(virtualMachine);
     }
 
+    /**
+     * Process the represented cluster in {@link WrappedElement} very
+     * similarly to the superclass, but adapted to take into account cloud
+     * machines and virtual machines.
+     *
+     * @param e {@link WrappedElement} representing a cluster.
+     */
     @Override
     protected void processClusterElement(final WrappedElement e) {
         if (e.isMaster()) {
@@ -113,6 +136,17 @@ public class CloudQueueNetworkBuilder extends QueueNetworkBuilder {
         }
     }
 
+    /**
+     * Build and process the cloud machine represented by the
+     * {@link WrappedElement} {@code e}. Since the machine may or may not be
+     * a master, it can be added to either the collection of
+     * {@link #virtualMachineMasters} or {@link #cloudMachines}.
+     *
+     * @param e {@link WrappedElement} representing a {@link CS_Processamento}.
+     * @return the interpreted {@link CS_Processamento} from the given
+     * {@link WrappedElement}. May either be a {@link CS_VMM} or a
+     * {@link CS_MaquinaCloud}.
+     */
     @Override
     protected CS_Processamento makeAndAddMachine(final WrappedElement e) {
         final CS_Processamento machine;
@@ -128,23 +162,41 @@ public class CloudQueueNetworkBuilder extends QueueNetworkBuilder {
         return machine;
     }
 
+    /**
+     * Differences from the overridden method:
+     * <ul>
+     *     <li>Always interprets {@code master} as an instance of
+     *     {@link CS_VMM}</li>
+     *     <li>{@code slave} may be a {@link CS_MaquinaCloud} instead of a
+     *     {@link CS_Maquina}</li>
+     * </ul>
+     *
+     * @param master the <b>master</b> {@link CS_Processamento}.
+     * @param slave  <b>slave</b> {@link CentroServico}.
+     */
     @Override
-    protected void addServiceCenterSlaves(
-            final CentroServico serviceCenter, final CS_Processamento m) {
-        final var master = (CS_VMM) m;
-        if (serviceCenter instanceof CS_Processamento proc) {
-            master.addEscravo(proc);
-            if (serviceCenter instanceof CS_MaquinaCloud machine) {
-                machine.addMestre(master);
+    protected void addSlavesToProcessingCenter(
+            final CS_Processamento master, final CentroServico slave) {
+        final var theMaster = (CS_VMM) master;
+        if (slave instanceof CS_Processamento proc) {
+            theMaster.addEscravo(proc);
+            if (slave instanceof CS_MaquinaCloud machine) {
+                machine.addMestre(theMaster);
             }
-        } else if (serviceCenter instanceof CS_Switch) {
-            for (final var slave : this.clusterSlaves.get(serviceCenter)) {
-                slave.addMestre(master);
-                master.addEscravo(slave);
+        } else if (slave instanceof CS_Switch) {
+            for (final var clusterSlave : this.clusterSlaves.get(slave)) {
+                clusterSlave.addMestre(theMaster);
+                theMaster.addEscravo(clusterSlave);
             }
         }
     }
 
+    /**
+     * Differently from the overridden method, iterates over {@link CS_VMM}s
+     * and updates {@link EscalonadorCloud}s.
+     *
+     * @param helper {@link UserPowerLimit} with the power limit information.
+     */
     @Override
     protected void setSchedulersUserMetrics(final UserPowerLimit helper) {
         this.virtualMachineMasters.stream()
@@ -153,6 +205,12 @@ public class CloudQueueNetworkBuilder extends QueueNetworkBuilder {
                 .forEach(helper::setSchedulerUserMetrics);
     }
 
+    /**
+     * Constructs a {@link RedeDeFilasCloud}. <b>It does not take power limit
+     * information into account.</b>
+     *
+     * @return initialized {@link RedeDeFilasCloud}.
+     */
     @Override
     protected RedeDeFilas initQueueNetwork() {
         return new RedeDeFilasCloud(

--- a/src/ispd/arquivo/xml/models/builders/QueueNetworkBuilder.java
+++ b/src/ispd/arquivo/xml/models/builders/QueueNetworkBuilder.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Class to build a queue network from a model in a {@link WrappedDocument}.
@@ -36,19 +35,16 @@ public class QueueNetworkBuilder {
             new HashMap<>(0);
     private final List<CS_Processamento> masters = new ArrayList<>();
     private final List<CS_Maquina> machines = new ArrayList<>();
-    private final Map<String, Double> powerLimits;
+    private final Map<String, Double> powerLimits = new HashMap<>();
 
-    public QueueNetworkBuilder(final WrappedDocument doc) {
-        this.powerLimits = doc.owners().collect(Collectors.toMap(
-                WrappedElement::id, o -> 0.0,
-                (prev, next) -> next, HashMap::new
-        ));
-
+    public QueueNetworkBuilder parseDoc(final WrappedDocument doc) {
+        doc.owners().forEach(o -> this.powerLimits.put(o.id(), 0.0));
         doc.machines().forEach(this::processMachineElement);
         doc.clusters().forEach(this::processClusterElement);
         doc.internets().forEach(this::processInternetElement);
         doc.links().forEach(this::processLinkElement);
         doc.masters().forEach(this::addSlavesToMachine);
+        return this;
     }
 
     private void processMachineElement(final WrappedElement e) {

--- a/src/ispd/arquivo/xml/models/builders/QueueNetworkBuilder.java
+++ b/src/ispd/arquivo/xml/models/builders/QueueNetworkBuilder.java
@@ -54,10 +54,10 @@ public class QueueNetworkBuilder {
             new HashMap<>(0);
     /**
      * Whether this instance has already parsed a document successfully.
-     * Every instance should be responsible for parsing <b>only one</b>
+     * Each instance should be responsible for parsing <b>only one</b>
      * document.
      */
-    private boolean hasParsedDoc = false;
+    private boolean hasParsedADocument = false;
 
     /**
      * Parse the required {@link CentroServico}s and user power limits from
@@ -71,7 +71,7 @@ public class QueueNetworkBuilder {
      *                               parse a {@link WrappedDocument}.
      */
     public QueueNetworkBuilder parseDocument(final WrappedDocument doc) {
-        if (this.hasParsedDoc) {
+        if (this.hasParsedADocument) {
             throw new IllegalStateException(
                     ".parseDocument(doc) method called twice.");
         }
@@ -83,7 +83,7 @@ public class QueueNetworkBuilder {
         doc.links().forEach(this::processLinkElement);
         doc.masters().forEach(this::addSlavesToMachine);
 
-        this.hasParsedDoc = true;
+        this.hasParsedADocument = true;
 
         return this;
     }
@@ -301,7 +301,7 @@ public class QueueNetworkBuilder {
     }
 
     private void throwIfNoDocumentWasParsed() {
-        if (!this.hasParsedDoc) {
+        if (!this.hasParsedADocument) {
             throw new IllegalStateException(
                     ".build() method called without a document parsed.");
         }

--- a/src/ispd/arquivo/xml/models/builders/QueueNetworkBuilder.java
+++ b/src/ispd/arquivo/xml/models/builders/QueueNetworkBuilder.java
@@ -4,6 +4,7 @@ import ispd.arquivo.xml.utils.SwitchConnection;
 import ispd.arquivo.xml.utils.UserPowerLimit;
 import ispd.arquivo.xml.utils.WrappedDocument;
 import ispd.arquivo.xml.utils.WrappedElement;
+import ispd.escalonador.Escalonador;
 import ispd.motor.filas.RedeDeFilas;
 import ispd.motor.filas.servidores.CS_Comunicacao;
 import ispd.motor.filas.servidores.CS_Processamento;
@@ -22,22 +23,53 @@ import java.util.Map;
 
 /**
  * Class to build a queue network from a model in a {@link WrappedDocument}.
- * Construct an instance and call the method {@link #build()}
+ * Usage should be as follows: <pre>{@code
+ * new QueueNetworkBuilder()
+ * .parseDocument(doc)
+ * .build();
+ * }</pre>
+ * See methods {@link #parseDocument(WrappedDocument)} and {@link #build()}
+ * for further details.
  *
  * @see ispd.arquivo.xml.IconicoXML
  */
 public class QueueNetworkBuilder {
+    /**
+     * Map or {@link CentroServico}s parsed from the document, indexed by id.
+     */
     protected final Map<Integer, CentroServico> serviceCenters =
             new HashMap<>();
+    /**
+     * Map of {@link CS_Internet}s parsed from the document.
+     */
     protected final List<CS_Internet> internets = new ArrayList<>();
+    /**
+     * Map of {@link CS_Link}s parsed from the document.
+     */
     protected final List<CS_Comunicacao> links = new ArrayList<>();
     private final Map<String, Double> powerLimits = new HashMap<>();
     private final List<CS_Maquina> machines = new ArrayList<>();
     private final List<CS_Processamento> masters = new ArrayList<>();
     private final Map<CentroServico, List<CS_Maquina>> clusterSlaves =
             new HashMap<>(0);
-    protected boolean hasParsedDoc = false;
+    /**
+     * Whether this instance has already parsed a document successfully.
+     * Every instance should be responsible for parsing <b>only one</b>
+     * document.
+     */
+    private boolean hasParsedDoc = false;
 
+    /**
+     * Parse the required {@link CentroServico}s and user power limits from
+     * the given {@link WrappedDocument}.
+     *
+     * @param doc the {@link WrappedDocument} to be processed. Must contain a
+     *            valid model.
+     * @return the called instance itself, so the call can be chained into a
+     * {@link #build()} if so desired.
+     * @throws IllegalStateException if this instance was already used to
+     *                               parse a {@link WrappedDocument}.
+     */
     public QueueNetworkBuilder parseDocument(final WrappedDocument doc) {
         if (this.hasParsedDoc) {
             throw new IllegalStateException(
@@ -67,6 +99,14 @@ public class QueueNetworkBuilder {
         );
     }
 
+    /**
+     * Process a {@link WrappedElement} that is representing a cluster of
+     * {@link CentroServico}s. The {@link CS_Mestre}, {@link CS_Maquina}s and
+     * {@link CS_Link}s in the cluster are differentiated and all processed
+     * individually.
+     *
+     * @param e {@link WrappedElement} representing a cluster.
+     */
     protected void processClusterElement(final WrappedElement e) {
         if (e.isMaster()) {
             final var cluster = ServiceCenterBuilder.aMasterWithNoLoad(e);
@@ -147,9 +187,20 @@ public class QueueNetworkBuilder {
                 .map(WrappedElement::id)
                 .map(Integer::parseInt)
                 .map(this.serviceCenters::get)
-                .forEach(sc -> this.addServiceCenterSlaves(sc, master));
+                .forEach(sc -> this.addSlavesToProcessingCenter(master, sc));
     }
 
+    /**
+     * Build and process the machine (more specifically, the
+     * {@link CS_Processamento} represented by the {@link WrappedElement}
+     * {@code e}. Since the machine may or may not be a master, it can be
+     * added to either the collection of {@link #masters} or {@link #machines}.
+     *
+     * @param e {@link WrappedElement} representing a {@link CS_Processamento}.
+     * @return the interpreted {@link CS_Processamento} from the given
+     * {@link WrappedElement}. May either be a {@link CS_Mestre} or a
+     * {@link CS_Maquina}.
+     */
     protected CS_Processamento makeAndAddMachine(final WrappedElement e) {
         final CS_Processamento machine;
 
@@ -164,10 +215,17 @@ public class QueueNetworkBuilder {
         return machine;
     }
 
-    protected void increaseUserPower(final String user,
-                                     final double increment) {
-        final var oldValue = this.powerLimits.get(user);
-        this.powerLimits.put(user, oldValue + increment);
+    /**
+     * Increase the power limit of the user with given id by the given amount.
+     *
+     * @param userId    id of the user whose power limit will be increased.
+     * @param increment amount to increment the power limit by. Should be
+     *                  <b>positive</b>.
+     */
+    protected void increaseUserPower(
+            final String userId, final double increment) {
+        final var oldValue = this.powerLimits.get(userId);
+        this.powerLimits.put(userId, oldValue + increment);
     }
 
     private static void connectLinkAndVertices(
@@ -183,25 +241,50 @@ public class QueueNetworkBuilder {
         return (Vertice) this.serviceCenters.get(e);
     }
 
-    protected void addServiceCenterSlaves(
-            final CentroServico serviceCenter, final CS_Processamento m) {
-        final var master = (CS_Mestre) m;
-        if (serviceCenter instanceof CS_Processamento proc) {
-            master.addEscravo(proc);
-            if (serviceCenter instanceof CS_Maquina machine) {
-                machine.addMestre(master);
+    /**
+     * Add {@link CentroServico} {@code slave} to the list of slaves of the
+     * {@link CS_Processamento} {@code master} (which is always interpreted
+     * as an instance of {@link CS_Mestre}. Note that {@code master} <b>is a
+     * master</b>, and {@link CS_Processamento} may either be:
+     * <ul>
+     *      <li>another master</li>
+     *      <li>a non-master machine</li>
+     *      <li>a switch</li>
+     * </ul>
+     * In any case, the method process the element appropriately and updates
+     * the necessary master-slave relations.
+     *
+     * @param master an instance of {@link CS_Mestre}.
+     * @param slave  <b>slave</b> {@link CentroServico}.
+     * @throws ClassCastException if the given {@link CS_Processamento}
+     *                            {@code master} is not an instance of
+     *                            {@link CS_Mestre}.
+     * @apiNote the parameter {@code master} is typed as a
+     * {@link CS_Processamento} to support overrides that deal with other
+     * types of masters. See
+     * {@link CloudQueueNetworkBuilder#addSlavesToProcessingCenter} for an
+     * example.
+     */
+    protected void addSlavesToProcessingCenter(
+            final CS_Processamento master, final CentroServico slave) {
+        final var theMaster = (CS_Mestre) master;
+        if (slave instanceof CS_Processamento proc) {
+            theMaster.addEscravo(proc);
+            if (slave instanceof CS_Maquina machine) {
+                machine.addMestre(theMaster);
             }
-        } else if (serviceCenter instanceof CS_Switch) {
-            for (final var slave : this.clusterSlaves.get(serviceCenter)) {
-                slave.addMestre(master);
-                master.addEscravo(slave);
+        } else if (slave instanceof CS_Switch) {
+            for (final var clusterSlave : this.clusterSlaves.get(slave)) {
+                clusterSlave.addMestre(theMaster);
+                theMaster.addEscravo(clusterSlave);
             }
         }
     }
 
     /**
      * Create a {@link RedeDeFilas} with the collections parsed from the
-     * document.
+     * document. The method {@link #parseDocument(WrappedDocument)} must
+     * already have been called on the instance.
      *
      * @return {@link RedeDeFilas} with the appropriate service centers,
      * links, and user configurations found in the document.
@@ -224,6 +307,13 @@ public class QueueNetworkBuilder {
         }
     }
 
+    /**
+     * For all {@link CS_Mestre}s parsed from the document, update its
+     * {@link Escalonador}'s user metrics with the obtained user power limit
+     * information.
+     *
+     * @param helper {@link UserPowerLimit} with the power limit information.
+     */
     protected void setSchedulersUserMetrics(final UserPowerLimit helper) {
         this.masters.stream()
                 .map(CS_Mestre.class::cast)
@@ -231,6 +321,12 @@ public class QueueNetworkBuilder {
                 .forEach(helper::setSchedulerUserMetrics);
     }
 
+    /**
+     * Construct a {@link RedeDeFilas} with the parsed {@link CentroServico}s
+     * and user power limit information.
+     *
+     * @return initialized {@link RedeDeFilas}.
+     */
     protected RedeDeFilas initQueueNetwork() {
         return new RedeDeFilas(
                 this.masters, this.machines,


### PR DESCRIPTION
Collection fields in subclass were uninitialized during document parsing. Now cloud simulations can actually run.